### PR TITLE
Fix user link navigation to take the current route into account

### DIFF
--- a/components/UserAvatar.js
+++ b/components/UserAvatar.js
@@ -7,9 +7,6 @@ import {
   Text,
   TouchableOpacity,
 } from 'react-native'
-import { last } from 'lodash'
-
-import NavigatorService from '../utilities/navigationService'
 
 import colors from '../constants/Colors'
 
@@ -42,26 +39,14 @@ const getStyles = size =>
 export default class UserAvatar extends React.Component {
   constructor(props) {
     super(props)
-    this.goToProfile = this.goToProfile.bind(this)
     this.styles = getStyles(props.size)
   }
 
-  goToProfile() {
-    const { user } = this.props
-    const { routeName, routes } = NavigatorService.getCurrentRoute()
-    const lastStack = last(routes)
-    if (lastStack.params && lastStack.params.id === user.slug) {
-      return false
-    }
-    const route = routeName === 'main' ? 'feedProfile' : 'profile'
-    return NavigatorService.navigate(route, { id: user.slug })
-  }
-
   render() {
-    const { user } = this.props
+    const { user, onPress } = this.props
     return (
       <TouchableOpacity
-        onPress={this.goToProfile}
+        onPress={onPress}
         style={[this.styles.container, this.props.style]}
       >
         <Text style={this.styles.initials} onPress={this.goToProfile}>
@@ -87,6 +72,7 @@ UserAvatar.fragments = {
 UserAvatar.propTypes = {
   size: PropTypes.number,
   style: PropTypes.any,
+  onPress: PropTypes.func,
   user: PropTypes.shape({
     name: PropTypes.string,
     slug: PropTypes.string,
@@ -98,5 +84,6 @@ UserAvatar.propTypes = {
 UserAvatar.defaultProps = {
   size: 40,
   style: {},
+  onPress: () => null,
 }
 

--- a/components/UserAvatar.js
+++ b/components/UserAvatar.js
@@ -46,9 +46,10 @@ export default class UserAvatar extends React.Component {
   }
 
   goToProfile() {
-    const { user, mode } = this.props
-    const routeName = mode === 'feed' ? 'feedProfile' : 'profile'
-    NavigatorService.navigate(routeName, { id: user.slug })
+    const { user } = this.props
+    const { routeName } = NavigatorService.getCurrentRoute()
+    const route = routeName === 'main' ? 'feedProfile' : 'profile'
+    NavigatorService.navigate(route, { id: user.slug })
   }
 
   render() {
@@ -76,7 +77,6 @@ UserAvatar.fragments = {
 }
 
 UserAvatar.propTypes = {
-  mode: PropTypes.oneOf(['feed', 'default']),
   user: PropTypes.shape({
     name: PropTypes.string,
     slug: PropTypes.string,

--- a/components/UserAvatar.js
+++ b/components/UserAvatar.js
@@ -7,6 +7,7 @@ import {
   Text,
   TouchableOpacity,
 } from 'react-native'
+import { last } from 'lodash'
 
 import NavigatorService from '../utilities/navigationService'
 
@@ -47,9 +48,13 @@ export default class UserAvatar extends React.Component {
 
   goToProfile() {
     const { user } = this.props
-    const { routeName } = NavigatorService.getCurrentRoute()
+    const { routeName, routes } = NavigatorService.getCurrentRoute()
+    const lastStack = last(routes)
+    if (lastStack.params && lastStack.params.id === user.slug) {
+      return false
+    }
     const route = routeName === 'main' ? 'feedProfile' : 'profile'
-    NavigatorService.navigate(route, { id: user.slug })
+    return NavigatorService.navigate(route, { id: user.slug })
   }
 
   render() {

--- a/components/UserNameText.js
+++ b/components/UserNameText.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { last } from 'lodash'
 import { StyleSheet, Text, TouchableOpacity } from 'react-native'
 
 import NavigatorService from '../utilities/navigationService'
@@ -26,16 +25,7 @@ export default class UserNameText extends React.Component {
   }
 
   goToProfile() {
-    const { user } = this.props
-    const { routeName, routes } = NavigatorService.getCurrentRoute()
-
-    const lastStack = last(routes)
-    if (lastStack.params && lastStack.params.id === user.id) {
-      return false
-    }
-
-    const route = routeName === 'home' ? 'feedProfile' : 'profile'
-    return NavigatorService.navigate(route, { id: user.slug })
+    NavigatorService.navigateToProfile(this.props.user.slug)
   }
 
   render() {

--- a/components/UserNameText.js
+++ b/components/UserNameText.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { last } from 'lodash'
 import { StyleSheet, Text, TouchableOpacity } from 'react-native'
 
 import NavigatorService from '../utilities/navigationService'
@@ -26,9 +27,15 @@ export default class UserNameText extends React.Component {
 
   goToProfile() {
     const { user } = this.props
-    const { routeName } = NavigatorService.getCurrentRoute()
-    const route = routeName === 'main' ? 'feedProfile' : 'profile'
-    NavigatorService.navigate(route, { id: user.slug })
+    const { routeName, routes } = NavigatorService.getCurrentRoute()
+
+    const lastStack = last(routes)
+    if (lastStack.params && lastStack.params.id === user.id) {
+      return false
+    }
+
+    const route = routeName === 'home' ? 'feedProfile' : 'profile'
+    return NavigatorService.navigate(route, { id: user.slug })
   }
 
   render() {

--- a/components/UserNameText.js
+++ b/components/UserNameText.js
@@ -25,9 +25,10 @@ export default class UserNameText extends React.Component {
   }
 
   goToProfile() {
-    const { user, mode } = this.props
-    const routeName = mode === 'feed' ? 'feedProfile' : 'profile'
-    NavigatorService.navigate(routeName, { id: user.slug })
+    const { user } = this.props
+    const { routeName } = NavigatorService.getCurrentRoute()
+    const route = routeName === 'main' ? 'feedProfile' : 'profile'
+    NavigatorService.navigate(route, { id: user.slug })
   }
 
   render() {
@@ -40,13 +41,8 @@ export default class UserNameText extends React.Component {
 }
 
 UserNameText.propTypes = {
-  mode: PropTypes.oneOf(['feed', 'default']),
   user: PropTypes.shape({
     name: PropTypes.string,
     slug: PropTypes.string,
   }).isRequired,
-}
-
-UserNameText.defaultProps = {
-  mode: 'default',
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "graphql-anywhere": "^1.0.0",
     "graphql-tag": "^1.1.2",
     "jest": "^20.0.4",
+    "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.12",
     "react-addons-test-utils": "16.0.0-alpha.3",

--- a/screens/FeedScreen/components/FeedContents.js
+++ b/screens/FeedScreen/components/FeedContents.js
@@ -7,6 +7,8 @@ import {
 import PropTypes from 'prop-types'
 import Carousel from 'react-native-snap-carousel'
 
+import NavigationService from '../../../utilities/navigationService'
+
 import BlockItem from '../../../components/BlockItem'
 import UserAvatar from '../../../components/UserAvatar'
 
@@ -22,7 +24,14 @@ const FeedContents = ({ items }) => {
           objectItem = <BlockItem size="1-up" block={item} key={item.id} />
           break
         case 'User':
-          objectItem = <UserAvatar user={item} key={item.id} mode="feed" />
+          objectItem = (
+            <UserAvatar
+              user={item}
+              key={item.id}
+              mode="feed"
+              onPress={() => NavigationService.navigateToProfile(item.slug)}
+            />
+          )
           break
         default:
           objectItem = <Text key={`klass-${item.id}`} >{item.id}</Text>

--- a/screens/FeedScreen/components/FeedWordLink.js
+++ b/screens/FeedScreen/components/FeedWordLink.js
@@ -18,7 +18,7 @@ const FeedWordLink = ({ object, phrase }) => {
         objectLink = <ChannelNameText channel={object} />
         break
       case 'User':
-        objectLink = <UserNameText mode="feed" user={object} />
+        objectLink = <UserNameText user={object} />
         break
       default:
         objectLink = <Text>{phrase || object.title} </Text>

--- a/utilities/navigationService.js
+++ b/utilities/navigationService.js
@@ -1,4 +1,5 @@
 import { NavigationActions } from 'react-navigation'
+import { last } from 'lodash'
 
 let _container; // eslint-disable-line
 
@@ -57,10 +58,21 @@ function getCurrentRoute() {
   return null
 }
 
+function navigateToProfile(id) {
+  const { routeName, routes } = getCurrentRoute()
+  const lastStack = last(routes)
+  if (lastStack.params && lastStack.params.id === id) {
+    return false
+  }
+  const route = routeName === 'home' ? 'feedProfile' : 'profile'
+  return navigate(route, { id })
+}
+
 export default {
   setContainer,
   navigateDeep,
   navigate,
   reset,
   getCurrentRoute,
+  navigateToProfile,
 }

--- a/utilities/navigationService.js
+++ b/utilities/navigationService.js
@@ -50,8 +50,11 @@ function getCurrentRoute() {
   if (!_container || !_container.state.nav) {
     return null
   }
-
-  return _container.state.nav.routes[_container.state.nav.index] || null
+  const firstStack = _container.state.nav.routes[_container.state.nav.index] || null
+  if (firstStack) {
+    return firstStack.routes[firstStack.index]
+  }
+  return null
 }
 
 export default {


### PR DESCRIPTION
Until this https://github.com/react-community/react-navigation/issues/135 gets solved, I'm handling this manually. 

The issue is twofold: 
1. on user links, we want to trigger the correct stack (either feed or profile)
2. on avatar, the we want to ignore touches if the current profile is the same user