### PR TITLE
Do not cache recent connections

### DIFF
--- a/components/SelectConnections/RecentConnections.js
+++ b/components/SelectConnections/RecentConnections.js
@@ -57,7 +57,7 @@ class RecentConnections extends Component {
   }
 }
 
-const RecentConnectionsQuery = gql`
+export const RecentConnectionsQuery = gql`
   query RecentConnectionsQuery {
     me {
       name
@@ -80,6 +80,6 @@ RecentConnections.defaultProps = {
   selected: [],
 }
 
-const RecentConnectionsWithData = graphql(RecentConnectionsQuery)(RecentConnections)
+const RecentConnectionsWithData = graphql(RecentConnectionsQuery, { options: { fetchPolicy: 'network-only' } })(RecentConnections)
 
 export default RecentConnectionsWithData

--- a/components/SelectConnections/RecentConnections.js
+++ b/components/SelectConnections/RecentConnections.js
@@ -57,7 +57,7 @@ class RecentConnections extends Component {
   }
 }
 
-export const RecentConnectionsQuery = gql`
+const RecentConnectionsQuery = gql`
   query RecentConnectionsQuery {
     me {
       name


### PR DESCRIPTION
If you add a connection that is not in the list, the next time you hit this screen it should be up to date. Hence, no cache.

(Related documentation: http://dev.apollodata.com/react/api-queries.html#graphql-config-options-fetchPolicy)