### PR TITLE
Enhance AddText, AddLink, and Connect screens

### DIFF
--- a/navigation/Routes.js
+++ b/navigation/Routes.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import { DrawerNavigator } from 'react-navigation'
+import { DrawerNavigator, StackNavigator } from 'react-navigation'
+import { enhance } from 'react-navigation-addons'
+
 import StackModalNavigator from '../utilities/stackModalNavigator'
 import LoggedOutScreen from '../screens/LoggedOutScreen'
 import LoginScreen from '../screens/LoginScreen'
@@ -83,13 +85,37 @@ export default initialRouteName => StackModalNavigator({
     },
   },
   newText: {
-    screen: AddTextScreen,
+    screen: enhance(StackNavigator)({
+      newText: { screen: AddTextScreen },
+    }),
+    navigationOptions: {
+      header: null,
+      cardStyle: {
+        backgroundColor: 'white',
+      },
+    },
   },
   newLink: {
-    screen: AddLinkScreen,
+    screen: enhance(StackNavigator)({
+      newLink: { screen: AddLinkScreen },
+    }),
+    navigationOptions: {
+      header: null,
+      cardStyle: {
+        backgroundColor: 'white',
+      },
+    },
   },
   connect: {
-    screen: AddConnectionsScreen,
+    screen: enhance(StackNavigator)({
+      connect: { screen: AddConnectionsScreen },
+    }),
+    navigationOptions: {
+      header: null,
+      cardStyle: {
+        backgroundColor: 'white',
+      },
+    },
   },
 }, {
   headerMode: 'screen',


### PR DESCRIPTION
This fixes app crash when adding text or links. Those screens update the header component by calling `setOptions` on the `navigation` prop but those only get set on `navigation` by using react-navigation-addons.