### PR TITLE
Disable header modal if it isn't expanded

### DIFF
--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -68,6 +68,7 @@ export default class Header extends Component {
       <HeaderModal
         isExpanded={isExpanded}
         onPress={this.onModalPress}
+        disabled={!isExpanded}
       >
         <HeaderPullDown
           primary={primary}


### PR DESCRIPTION
So that it won't interfere with HeaderIcons when not active.