### PR TITLE
Fetch from block from cache first and then load the full block

### DIFF
--- a/components/BlockItem.js
+++ b/components/BlockItem.js
@@ -140,6 +140,9 @@ BlockItem.fragments = {
         name
       }
       klass
+      source {
+        url
+      }
       kind {
         __typename
         ... on Block {


### PR DESCRIPTION
This changes the block lightbox render to use Apollo's fragment cache first and then render the block afterwards.