### PR TITLE
Uses returned phrase by default over block title

### DIFF
--- a/components/BlockLink.js
+++ b/components/BlockLink.js
@@ -14,17 +14,17 @@ export default class BlockText extends React.Component {
   }
 
   render() {
-    const { block: { title, kind: { __typename } }, ...rest } = this.props
-
+    const { phrase, block: { title, kind: { __typename } }, ...rest } = this.props
     return (
       <Text onPress={this.goToBlock} {...rest}>
-        {title || `${__typename.match(/^[AEIOU]/) ? 'an' : 'a'} ${__typename.toLowerCase()}`}
+        {phrase || title || `${__typename.match(/^[AEIOU]/) ? 'an' : 'a'} ${__typename.toLowerCase()}`}
       </Text>
     )
   }
 }
 
 BlockText.propTypes = {
+  phrase: PropTypes.string,
   block: PropTypes.shape({
     id: PropTypes.any.isRequired,
     title: PropTypes.string,
@@ -33,5 +33,6 @@ BlockText.propTypes = {
 }
 
 BlockText.defaultProps = {
+  phrase: '',
   onPress: () => null,
 }

--- a/components/FeedWordLink.js
+++ b/components/FeedWordLink.js
@@ -21,7 +21,7 @@ const FeedWordLink = ({ object, phrase, ...rest }) => {
         link = <UserNameText user={object} {...rest} />
         break
       case 'Connectable':
-        link = <BlockLink block={object} {...rest} />
+        link = <BlockLink block={object} phrase={phrase} {...rest} />
         break
       default:
         link = <Text {...rest}>{phrase || object.title}</Text>


### PR DESCRIPTION
Before: 
![screenshot 2017-10-19 12 26 14](https://user-images.githubusercontent.com/821469/31782434-dfb22384-b4c8-11e7-9195-14aa5e9ac15a.png)
After: 
![screenshot 2017-10-19 12 26 25](https://user-images.githubusercontent.com/821469/31782433-dfa182f4-b4c8-11e7-9605-936413cb6466.png)