### PR TITLE
Fix connect routing

### DIFF
--- a/components/Form/ChannelForm.js
+++ b/components/Form/ChannelForm.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+
 import HeaderRightButton from '../HeaderRightButton'
 import NavigatorService from '../../utilities/navigationService'
 import { Section, Container } from '../../components/UI/Layout'
@@ -71,35 +73,37 @@ class ChannelForm extends React.Component {
 
     return (
       <Container>
-        <Section space={4}>
-          <FieldsetLabel>
-            Title / Description
-          </FieldsetLabel>
+        <KeyboardAwareScrollView>
+          <Section space={4}>
+            <FieldsetLabel>
+              Title / Description
+            </FieldsetLabel>
 
-          <Fieldset>
-            <StackedInput
-              placeholder="Title"
-              onChangeText={this.onChangeText('title')}
-              value={title}
-              autoFocus
-            />
+            <Fieldset>
+              <StackedInput
+                placeholder="Title"
+                onChangeText={this.onChangeText('title')}
+                value={title}
+                autoFocus
+              />
 
-            <StackedTextArea
-              name="description"
-              placeholder="Description (optional)"
-              value={description}
-              onChangeText={this.onChangeText('description')}
-            />
-          </Fieldset>
-        </Section>
+              <StackedTextArea
+                name="description"
+                placeholder="Description (optional)"
+                value={description}
+                onChangeText={this.onChangeText('description')}
+              />
+            </Fieldset>
+          </Section>
 
-        <Section>
-          <Fieldset>
-            <StackedJumpButton label="Privacy" onPress={this.goToChannelVisibilityScreen}>
-              {capitalize(visibility.toLowerCase())}
-            </StackedJumpButton>
-          </Fieldset>
-        </Section>
+          <Section>
+            <Fieldset>
+              <StackedJumpButton label="Privacy" onPress={this.goToChannelVisibilityScreen}>
+                {capitalize(visibility.toLowerCase())}
+              </StackedJumpButton>
+            </Fieldset>
+          </Section>
+        </KeyboardAwareScrollView>
       </Container>
     )
   }

--- a/components/Form/ImageForm.js
+++ b/components/Form/ImageForm.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 
 import { Container } from '../../components/UI/Layout'
 import FieldSet from '../FieldSet'
@@ -59,25 +60,27 @@ export default class ImageForm extends React.Component {
     const { image, title, description } = this.state
     return (
       <Container>
-        <ImagePreview source={{ uri: image }} />
-        <Field
-          isFirst
-          label="Title / Description"
-          onChange={this.onFieldChange}
-          fields={[
-            {
-              key: 'title',
-              placeholder: 'Title',
-              value: title,
-            },
-            {
-              key: 'description',
-              placeholder: 'Description',
-              type: 'textarea',
-              value: description,
-            },
-          ]}
-        />
+        <KeyboardAwareScrollView>
+          <ImagePreview source={{ uri: image }} />
+          <Field
+            isFirst
+            label="Title / Description"
+            onChange={this.onFieldChange}
+            fields={[
+              {
+                key: 'title',
+                placeholder: 'Title',
+                value: title,
+              },
+              {
+                key: 'description',
+                placeholder: 'Description',
+                type: 'textarea',
+                value: description,
+              },
+            ]}
+          />
+        </KeyboardAwareScrollView>
       </Container>
     )
   }

--- a/components/Form/ImageForm.js
+++ b/components/Form/ImageForm.js
@@ -1,19 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 
+import { Container } from '../../components/UI/Layout'
 import FieldSet from '../FieldSet'
 import HeaderRightButton from '../HeaderRightButton'
 
 import { Units, Border } from '../../constants/Style'
 
 const contentWidth = (Units.window.width - (Units.scale[4] * 2))
-
-const Container = styled(KeyboardAwareScrollView)`
-  flex: 1;
-  background-color: white;
-`
 
 const Field = styled(FieldSet)`
   margin-top: ${Units.scale[4]};

--- a/components/Form/LinkForm.js
+++ b/components/Form/LinkForm.js
@@ -1,18 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { isURL } from 'validator'
 
 import FieldSet from '../FieldSet'
 import HeaderRightButton from '../HeaderRightButton'
+import { Container } from '../../components/UI/Layout'
 
 import { Units } from '../../constants/Style'
-
-const Container = styled(KeyboardAwareScrollView)`
-  flex: 1;
-  background-color: white;
-`
 
 const Field = styled(FieldSet)`
   margin-top: ${Units.scale[4]};

--- a/components/Form/LinkForm.js
+++ b/components/Form/LinkForm.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
 import { isURL } from 'validator'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 
 import FieldSet from '../FieldSet'
 import HeaderRightButton from '../HeaderRightButton'
@@ -64,37 +65,39 @@ export default class LinkForm extends React.Component {
     const hasProcessed = (title || description)
     return (
       <Container>
-        <Field
-          isFirst
-          label="Link"
-          onChange={this.onFieldChange}
-          fields={[
-            {
-              key: 'source_url',
-              placeholder: 'URL',
-              type: 'url',
-              value: source_url,
-              editable: !hasProcessed,
-            },
-          ]}
-        />
-        {hasProcessed && <Field
-          label="Title / Description"
-          onChange={this.onFieldChange}
-          fields={[
-            {
-              key: 'title',
-              placeholder: 'Title',
-              value: this.state.title,
-            },
-            {
-              key: 'description',
-              placeholder: 'Description',
-              value: this.state.description,
-              type: 'textarea',
-            },
-          ]}
-        />}
+        <KeyboardAwareScrollView>
+          <Field
+            isFirst
+            label="Link"
+            onChange={this.onFieldChange}
+            fields={[
+              {
+                key: 'source_url',
+                placeholder: 'URL',
+                type: 'url',
+                value: source_url,
+                editable: !hasProcessed,
+              },
+            ]}
+          />
+          {hasProcessed && <Field
+            label="Title / Description"
+            onChange={this.onFieldChange}
+            fields={[
+              {
+                key: 'title',
+                placeholder: 'Title',
+                value: this.state.title,
+              },
+              {
+                key: 'description',
+                placeholder: 'Description',
+                value: this.state.description,
+                type: 'textarea',
+              },
+            ]}
+          />}
+        </KeyboardAwareScrollView>
       </Container>
     )
   }

--- a/components/Form/TextForm.js
+++ b/components/Form/TextForm.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 
 import FieldSet from '../FieldSet'
 import HeaderRightButton from '../HeaderRightButton'
@@ -55,34 +56,36 @@ export default class TextForm extends React.Component {
   render() {
     return (
       <Container>
-        <FieldSet
-          label="Text"
-          onChange={this.onFieldChange}
-          fields={[
-            {
-              key: 'content',
-              placeholder: 'Text',
-              type: 'textarea',
-              value: this.state.content,
-            },
-          ]}
-        />
-        <Field
-          label="Title / Description"
-          onChange={this.onFieldChange}
-          fields={[
-            {
-              key: 'title',
-              placeholder: 'Title',
-              value: this.state.title,
-            },
-            {
-              key: 'description',
-              placeholder: 'Description',
-              value: this.state.description,
-            },
-          ]}
-        />
+        <KeyboardAwareScrollView>
+          <FieldSet
+            label="Text"
+            onChange={this.onFieldChange}
+            fields={[
+              {
+                key: 'content',
+                placeholder: 'Text',
+                type: 'textarea',
+                value: this.state.content,
+              },
+            ]}
+          />
+          <Field
+            label="Title / Description"
+            onChange={this.onFieldChange}
+            fields={[
+              {
+                key: 'title',
+                placeholder: 'Title',
+                value: this.state.title,
+              },
+              {
+                key: 'description',
+                placeholder: 'Description',
+                value: this.state.description,
+              },
+            ]}
+          />
+        </KeyboardAwareScrollView>
       </Container>
     )
   }

--- a/components/Form/TextForm.js
+++ b/components/Form/TextForm.js
@@ -1,17 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 
 import FieldSet from '../FieldSet'
 import HeaderRightButton from '../HeaderRightButton'
+import { Container } from '../../components/UI/Layout'
 
 import { Units } from '../../constants/Style'
-
-const Container = styled(KeyboardAwareScrollView)`
-  flex: 1;
-  background-color: white;
-`
 
 const Field = styled(FieldSet)`
   margin-top: ${Units.scale[4]};

--- a/navigation/MainStack.js
+++ b/navigation/MainStack.js
@@ -8,6 +8,7 @@ import BlockTextScreen from '../screens/BlockScreen/components/BlockText' // TOD
 import ChannelScreen from '../screens/ChannelScreen'
 import CommentScreen from '../screens/CommentScreen'
 import FeedScreen from '../screens/FeedScreen'
+import SearchScreen from '../screens/SearchScreen'
 import ProfileScreen from '../screens/ProfileScreen'
 import UserSettingsScreen from '../screens/UserSettingsScreen'
 import EditChannelScreen from '../screens/EditChannelScreen'
@@ -16,6 +17,11 @@ import NewChannelScreen from '../screens/NewChannelScreen'
 import ChannelVisibility from '../components/ChannelVisibility' // TODO: Move this to screens
 import EditAccountNameScreen from '../screens/EditAccountScreens/EditAccountNameScreen'
 import EditEmailNotificationsScreen from '../screens/EditAccountScreens/EditEmailNotificationsScreen'
+
+import AddTextScreen from '../screens/AddTextScreen'
+import AddImageScreen from '../screens/AddImageScreen'
+import AddLinkScreen from '../screens/AddLinkScreen'
+import AddConnectionsScreen from '../screens/AddConnectionScreen'
 
 import Header from '../components/Header'
 import HeaderIcon from '../screens/FeedScreen/components/HeaderIcons'
@@ -127,6 +133,44 @@ export default enhance(StackNavigator)({
         ]}
       />,
     }),
+  },
+
+  search: {
+    screen: SearchScreen,
+    navigationOptions: {
+      header: null,
+      cardStyle: {
+        backgroundColor: 'white',
+      },
+    },
+  },
+
+  newText: {
+    screen: AddTextScreen,
+    navigationOptions: {
+      ...headerNavigationOptions,
+    },
+  },
+
+  newImage: {
+    screen: AddImageScreen,
+    navigationOptions: {
+      ...headerNavigationOptions,
+    },
+  },
+
+  newLink: {
+    screen: AddLinkScreen,
+    navigationOptions: {
+      ...headerNavigationOptions,
+    },
+  },
+
+  connect: {
+    screen: AddConnectionsScreen,
+    navigationOptions: {
+      ...headerNavigationOptions,
+    },
   },
 
   editAccountName: {

--- a/navigation/Routes.js
+++ b/navigation/Routes.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { DrawerNavigator, StackNavigator } from 'react-navigation'
-import { enhance } from 'react-navigation-addons'
+import { DrawerNavigator } from 'react-navigation'
 
 import StackModalNavigator from '../utilities/stackModalNavigator'
 import LoggedOutScreen from '../screens/LoggedOutScreen'
@@ -8,13 +7,6 @@ import LoginScreen from '../screens/LoginScreen'
 import SignUpScreen from '../screens/SignUpScreen'
 import MainStack from './MainStack'
 import NotificationsScreen from '../screens/NotificationsScreen'
-import SearchScreen from '../screens/SearchScreen'
-import AddTextScreen from '../screens/AddTextScreen'
-import AddImageScreen from '../screens/AddImageScreen'
-import AddLinkScreen from '../screens/AddLinkScreen'
-import AddConnectionsScreen from '../screens/AddConnectionScreen'
-
-import headerNavigationOptions from '../constants/Header'
 
 const MainStackWithDrawer = DrawerNavigator({
   feed: {
@@ -69,55 +61,6 @@ export default initialRouteName => StackModalNavigator({
         backgroundColor: 'white',
       },
     },
-  },
-
-  search: {
-    screen: SearchScreen,
-    navigationOptions: {
-      header: null,
-      cardStyle: {
-        backgroundColor: 'white',
-      },
-    },
-  },
-
-  // TODO: Pull these onto the main stack
-  newText: {
-    screen: enhance(StackNavigator)({
-      newText: { screen: AddTextScreen },
-    }),
-    navigationOptions: {
-      ...headerNavigationOptions,
-    },
-  },
-
-  newImage: {
-    screen: enhance(StackNavigator)({
-      newText: { screen: AddImageScreen },
-    }),
-    navigationOptions: {
-      ...headerNavigationOptions,
-    },
-  },
-
-  newLink: {
-    screen: enhance(StackNavigator)({
-      newLink: { screen: AddLinkScreen },
-    }),
-    navigationOptions: {
-      ...headerNavigationOptions,
-    },
-  },
-
-  connect: {
-    screen: enhance(StackNavigator)({
-      connect: {
-        screen: AddConnectionsScreen,
-        navigationOptions: {
-          ...headerNavigationOptions,
-        },
-      },
-    }),
   },
 }, {
   headerMode: 'screen',

--- a/screens/AddConnectionScreen/index.js
+++ b/screens/AddConnectionScreen/index.js
@@ -183,8 +183,8 @@ class SelectConnectionScreen extends React.Component {
           Keyboard.dismiss()
           const { data: { create_block: { block } } } = response
           this.navigateToBlock(block.id, image && image.location)
-        })
-      })
+        }).catch(alertErrors)
+      }).catch(alertErrors)
   }
 
   search = (text) => {

--- a/screens/AddConnectionScreen/index.js
+++ b/screens/AddConnectionScreen/index.js
@@ -183,7 +183,7 @@ class SelectConnectionScreen extends React.Component {
           Keyboard.dismiss()
           const { data: { create_block: { block } } } = response
           this.navigateToBlock(block.id, image && image.location)
-        }).catch(alertErrors)
+        })
       }).catch(alertErrors)
   }
 

--- a/screens/AddConnectionScreen/index.js
+++ b/screens/AddConnectionScreen/index.js
@@ -123,7 +123,7 @@ class SelectConnectionScreen extends React.Component {
 
   navigateToBlock(id, imageLocation) {
     this.setState({ selectedConnections: [] })
-    navigationService.reset('block', { id, imageLocation })
+    navigationService.navigate('block', { id, imageLocation })
   }
 
 


### PR DESCRIPTION
Routing after block creation was broken, it is no longer. I did however revert the change to make the navigation after connect `reset` instead of `navigate` after realizing what a piece of shit `reset` is (it animates the entire reset).