### PR TITLE
Navigate to block via reset

### DIFF
--- a/screens/AddConnectionScreen/index.js
+++ b/screens/AddConnectionScreen/index.js
@@ -123,7 +123,7 @@ class SelectConnectionScreen extends React.Component {
 
   navigateToBlock(id, imageLocation) {
     this.setState({ selectedConnections: [] })
-    navigationService.navigate('block', { id, imageLocation })
+    navigationService.reset('block', { id, imageLocation })
   }
 
 


### PR DESCRIPTION
Seems like a fix for the weird transition here is actually coming: https://github.com/react-community/react-navigation/issues/1493