### PR TITLE
Re-includes navigateOnce hack

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ import navigationService from './utilities/navigationService'
 import cacheAssetsAsync from './utilities/cacheAssetsAsync'
 import currentUserService from './utilities/currentUserService'
 import { trackPage } from './utilities/analytics'
+import navigateOnce from './utilities/navigateOnce'
 
 import cachedAssets from './cachedAssets'
 
@@ -85,6 +86,7 @@ class AppContainer extends Component {
   render() {
     if (this.state.isReady) {
       const Navigation = createRootNavigator(this.getInitialRoute())
+      Navigation.router.getStateForAction = navigateOnce(Navigation.router.getStateForAction)
 
       return (
         <ApolloProvider store={Store} client={Client}>

--- a/utilities/navigateOnce.js
+++ b/utilities/navigateOnce.js
@@ -1,3 +1,6 @@
+// NOTE: Taken from
+// https://github.com/react-community/react-navigation/issues/271#issuecomment-303217976
+
 import { NavigationActions } from 'react-navigation'
 
 const navigateOnce = getStateForAction => (action, state) => {
@@ -13,7 +16,6 @@ const navigateOnce = getStateForAction => (action, state) => {
     routeName === latestRoute.routeName &&
     possibleId === latestId
   ) ? null : getStateForAction(action, state)
-  // you might want to replace 'null' with 'state' if you're using redux (see comments below)
 }
 
 export default navigateOnce


### PR DESCRIPTION
I guess https://github.com/react-community/react-navigation/issues/135 is the canonical issue for this. Everyday I'm baffled this library has as much mindshare as it does. I'd love to use something else at this point.