### PR TITLE
Supports tablet

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     },
     "ios": {
       "loadJSInBackgroundExperimental": false,
-      "supportsTablet": false,
+      "supportsTablet": true,
       "bundleIdentifier": "na.are.arenaapp",
       "config": {
         "usesNonExemptEncryption": false


### PR DESCRIPTION
<img width="994" alt="screenshot 2017-12-22 13 31 07" src="https://user-images.githubusercontent.com/821469/34308675-6c360da4-e71c-11e7-842f-a97b1ce40601.png">

This shouldn't have been false, my fault. Will need to deploy a new version.